### PR TITLE
Fix `componentWillUpdate` has been renamed warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,19 +38,16 @@ export default class Lottie extends React.Component {
     this.setAnimationControl();
   }
 
-  componentWillUpdate(nextProps /* , nextState */) {
-    /* Recreate the animation handle if the data is changed */
-    if (this.options.animationData !== nextProps.options.animationData) {
-      this.deRegisterEvents(this.props.eventListeners);
+  componentDidUpdate(prevProps) {
+    if (prevProps.options.animationData !== this.props.options.animationData) {
+      this.deRegisterEvents(prevProps.eventListeners);
       this.destroy();
-      this.options = { ...this.options, ...nextProps.options };
+      this.options = { ...prevProps.options, ...this.props.options };
       this.anim = lottie.loadAnimation(this.options);
       this.animApi = lottieApi.createAnimationApi(this.anim);
-      this.registerEvents(nextProps.eventListeners);
+      this.registerEvents(this.props.eventListeners);
     }
-  }
-
-  componentDidUpdate() {
+    
     if (this.props.isStopped) {
       this.stop();
     } else if (this.props.segments) {


### PR DESCRIPTION
Moves the extraction of props and eventListeners logic from `componentWillUpdate` to `componentDidUpdate`. This fixes the following warning from the console:

```
Warning: componentWillUpdate has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Lottie
```